### PR TITLE
Fix admin login submit button

### DIFF
--- a/frontend/src/pages/admin/AdminLogin.tsx
+++ b/frontend/src/pages/admin/AdminLogin.tsx
@@ -44,7 +44,7 @@ const AdminLogin: React.FC = () => {
           {error ? <div className="ui-field-message ui-field-message--error">{error}</div> : null}
           <Field label="البريد الإلكتروني"><Input type="email" value={email} onChange={(event) => setEmail(event.target.value)} placeholder="admin@nafas.com" /></Field>
           <Field label="كلمة المرور"><Input type="password" value={password} onChange={(event) => setPassword(event.target.value)} placeholder="••••••••" /></Field>
-          <Button fullWidth size="lg" disabled={loading}>{loading ? 'جارِ الدخول...' : 'دخول لوحة التحكم'}</Button>
+          <Button type="submit" fullWidth size="lg" disabled={loading}>{loading ? 'جارِ الدخول...' : 'دخول لوحة التحكم'}</Button>
         </form>
       </Card>
     </div>


### PR DESCRIPTION
## Summary
- Set the admin login form button to `type="submit"` so browser clicks submit the form.
- Keep the shared Button default unchanged.
- No homepage, checkout public flow, catalog, or Phase 2 files touched.

## Validation
- `npm run lint`
- `npm run build`
- `npm test`
- `npm run test:responsive`
- Browser QA: `/admin/login` submits and navigates to `/admin/dashboard`.
- Browser QA: manual payment approve/reject works from admin order detail for Vodafone Cash and Instapay orders.

## Scope
Bugfix PR only. One frontend file changed.