### PR TITLE
Phase 2A conversion sales UX

### DIFF
--- a/frontend/src/pages/Checkout.tsx
+++ b/frontend/src/pages/Checkout.tsx
@@ -229,19 +229,19 @@ export default function Checkout() {
               {
                 key: 'cash_on_delivery',
                 title: locale === 'ar' ? 'الدفع عند الاستلام' : 'Cash on delivery',
-                body: locale === 'ar' ? 'ادفع نقدًا عند وصول الطلب.' : 'Pay in cash when your order arrives.',
+                body: locale === 'ar' ? 'اختيار بسيط: ادفع نقدًا عند وصول الطلب، بدون رقم مرجع أو مراجعة تحويل.' : 'Simple option: pay in cash when your order arrives, with no transfer reference required.',
                 destination: '',
               },
               {
                 key: 'vodafone_cash',
                 title: locale === 'ar' ? 'فودافون كاش' : 'Vodafone Cash',
-                body: locale === 'ar' ? 'حوّل المبلغ على الرقم الموضح، ثم اكتب رقم العملية أو المرجع ليتم مراجعة الدفع يدويًا.' : 'Transfer to the configured number, then enter the transaction reference for manual review.',
+                body: locale === 'ar' ? 'حوّل المبلغ على الرقم الموضح، ثم اكتب رقم العملية أو المرجع ليتم مراجعة الدفع يدويًا قبل تأكيد التجهيز.' : 'Transfer to the configured number, then enter the transaction reference so the team can manually review payment before preparation.',
                 destination: VODAFONE_CASH_NUMBER,
               },
               {
                 key: 'instapay',
                 title: locale === 'ar' ? 'إنستاباي' : 'Instapay',
-                body: locale === 'ar' ? 'حوّل المبلغ عبر حساب إنستاباي الموضح، ثم اكتب رقم العملية أو المرجع ليتم مراجعة الدفع يدويًا.' : 'Pay through the configured Instapay account, then enter the transaction reference for manual review.',
+                body: locale === 'ar' ? 'حوّل المبلغ عبر حساب إنستاباي الموضح، ثم اكتب رقم العملية أو المرجع ليتم مراجعة الدفع يدويًا قبل تأكيد التجهيز.' : 'Pay through the configured Instapay account, then enter the transaction reference so the team can manually review payment before preparation.',
                 destination: INSTAPAY_HANDLE,
               },
             ].map((method) => (
@@ -312,8 +312,8 @@ export default function Checkout() {
                 </label>
                 <small className="field-hint is-wide">
                   {locale === 'ar'
-                    ? 'رفع صورة إثبات الدفع غير مفعل في هذه المرحلة. سيُراجع الفريق رقم العملية يدويًا.'
-                    : 'Proof image upload is not enabled in this phase. The team will review the transaction reference manually.'}
+                    ? 'بعد التحويل، اكتب رقم العملية أو المرجع فقط. رفع صورة إثبات الدفع غير مفعل في هذه المرحلة، وسيُراجع الفريق التحويل يدويًا.'
+                    : 'After transferring, enter the transaction reference only. Proof image upload is not enabled in this phase, and the team will review the transfer manually.'}
                 </small>
               </div>
             ) : null}

--- a/frontend/src/pages/ProductDetail.tsx
+++ b/frontend/src/pages/ProductDetail.tsx
@@ -1,6 +1,6 @@
 import { Gift, Heart, Minus, MoonStar, Plus, Shield, Snowflake, Users } from 'lucide-react';
 import { useEffect, useMemo, useState } from 'react';
-import { Link, useParams } from 'react-router-dom';
+import { Link, useLocation, useParams } from 'react-router-dom';
 import { getCachedProduct, getCachedProducts } from '../cache/productCache';
 import ProductCard from '../components/ProductCard';
 import ProductGallery from '../components/ProductGallery';
@@ -10,9 +10,10 @@ import { useLocale } from '../context/LocaleContext';
 import { useCart } from '../hooks/useCart';
 import { useEngagement } from '../hooks/useEngagement';
 import type { Product } from '../types/store';
-import { HAS_WHATSAPP_SUPPORT, WHATSAPP_SUPPORT_URL } from '../utils/brand';
+import { HAS_WHATSAPP_SUPPORT } from '../utils/brand';
 import { formatCurrency, formatNumber } from '../utils/format';
 import { getPrimaryVariant } from '../utils/products';
+import { buildProductWhatsAppUrl } from '../utils/whatsapp';
 
 function getMeterScore(label?: string) {
   const value = String(label || '').toLowerCase();
@@ -109,6 +110,7 @@ function ScentWheel({ locale, notes }: { locale: 'ar' | 'en'; notes: string[] })
 
 export default function ProductDetail() {
   const { slug = '' } = useParams();
+  const location = useLocation();
   const { locale } = useLocale();
   const { addToCart, openCart } = useCart();
   const { getProductMetrics, registerView, toggleFavorite } = useEngagement();
@@ -138,7 +140,14 @@ export default function ProductDetail() {
       });
   }, [registerView, slug]);
 
-  const related = useMemo(() => products.filter((item) => item.slug !== slug).slice(0, 3), [products, slug]);
+  const isDiscoverySet = slug === 'discovery-set';
+  const related = useMemo(() => {
+    const candidates = products.filter((item) => item.slug !== slug);
+    const discoverySet = !isDiscoverySet ? candidates.find((item) => item.slug === 'discovery-set') : null;
+    const others = candidates.filter((item) => item.slug !== 'discovery-set');
+
+    return [...(discoverySet ? [discoverySet] : []), ...others].slice(0, 3);
+  }, [isDiscoverySet, products, slug]);
   const metrics = product ? getProductMetrics(product) : null;
 
   const selectedVariant = useMemo(() => {
@@ -157,6 +166,13 @@ export default function ProductDetail() {
   const moodTags = locale === 'ar' ? product?.tags_ar || [] : product?.tags_en || [];
   const longevityScore = getMeterScore(locale === 'ar' ? product?.longevity_label_ar || product?.longevity_label : product?.longevity_label_en || product?.longevity_label);
   const projectionScore = getMeterScore(locale === 'ar' ? product?.projection_label_ar || product?.projection_label : product?.projection_label_en || product?.projection_label);
+  const productWhatsAppUrl = product && selectedVariant ? buildProductWhatsAppUrl({
+    locale,
+    path: location.pathname,
+    product,
+    quantity,
+    variant: selectedVariant,
+  }) : '';
 
   useEffect(() => {
     if (!selectedVariantId) {
@@ -245,6 +261,39 @@ export default function ProductDetail() {
             </button>
           </Reveal>
 
+          {isDiscoverySet ? (
+            <Reveal className="story-card is-open" delay={140}>
+              <h2>{locale === 'ar' ? 'ليه مجموعة التجربة؟' : 'Why the Discovery Set?'}</h2>
+              <div className="story-card__text">
+                <p>
+                  {locale === 'ar'
+                    ? '6 عينات من عطور نافَس تساعدك تختار بهدوء، تجرب الرائحة على بشرتك، وتاخد خطوة آمنة قبل شراء الزجاجة الكبيرة.'
+                    : 'Six Nafas samples to help you choose calmly, test each scent on your skin, and decide before buying a full bottle.'}
+                </p>
+              </div>
+              <div className="who-tags" aria-label={locale === 'ar' ? 'مميزات مجموعة التجربة' : 'Discovery Set benefits'}>
+                <span className="who-tag">{locale === 'ar' ? '6 عينات من عطور نافَس' : '6 Nafas samples'}</span>
+                <span className="who-tag">{locale === 'ar' ? 'مناسب لو محتار تختار أنهي عطر' : 'Useful when you are unsure which scent fits'}</span>
+                <span className="who-tag">{locale === 'ar' ? 'جرّب على بشرتك قبل الزجاجة الكبيرة' : 'Try on skin before the full bottle'}</span>
+                <span className="who-tag">{locale === 'ar' ? 'خطوة آمنة قبل شراء الحجم الكبير' : 'A safer step before the larger size'}</span>
+              </div>
+            </Reveal>
+          ) : (
+            <Reveal className="story-card is-open" delay={140}>
+              <h2>{locale === 'ar' ? 'مش متأكد؟' : 'Still choosing?'}</h2>
+              <div className="story-card__text">
+                <p>
+                  {locale === 'ar'
+                    ? 'جرّب مجموعة التجربة الأول لو محتار بين الروائح. ولو العطر هدية، مقاس 30ml أو مجموعة التجربة اختيار أخف وأسهل.'
+                    : 'Try the Discovery Set first if you are choosing between scents. For gifting, the 30ml size or Discovery Set is a lighter, easier choice.'}
+                </p>
+              </div>
+              <Link to="/products/discovery-set" className="inline-link">
+                {locale === 'ar' ? 'شوف مجموعة التجربة' : 'View Discovery Set'}
+              </Link>
+            </Reveal>
+          )}
+
           <Reveal className="variant-card" delay={160}>
             <h2>{locale === 'ar' ? 'الأحجام' : 'Variants'}</h2>
             <div className="variant-grid">
@@ -312,8 +361,8 @@ export default function ProductDetail() {
                   {locale === 'ar' ? 'أضف إلى السلة' : 'Add to cart'}
                 </button>
 
-                {HAS_WHATSAPP_SUPPORT ? (
-                  <a href={WHATSAPP_SUPPORT_URL} target="_blank" rel="noreferrer" className="n-btn n-btn--ghost n-btn--full">
+                {HAS_WHATSAPP_SUPPORT && productWhatsAppUrl ? (
+                  <a href={productWhatsAppUrl} target="_blank" rel="noreferrer" className="n-btn n-btn--ghost n-btn--full">
                     {locale === 'ar' ? 'استفسر عبر واتساب' : 'Ask on WhatsApp'}
                   </a>
                 ) : null}

--- a/frontend/src/pages/ProductDetail.tsx
+++ b/frontend/src/pages/ProductDetail.tsx
@@ -267,12 +267,12 @@ export default function ProductDetail() {
               <div className="story-card__text">
                 <p>
                   {locale === 'ar'
-                    ? '6 عينات من عطور نافَس تساعدك تختار بهدوء، تجرب الرائحة على بشرتك، وتاخد خطوة آمنة قبل شراء الزجاجة الكبيرة.'
+                    ? '6 عينات من عطور نفَس تساعدك تختار بهدوء، تجرب الرائحة على بشرتك، وتاخد خطوة آمنة قبل شراء الزجاجة الكبيرة.'
                     : 'Six Nafas samples to help you choose calmly, test each scent on your skin, and decide before buying a full bottle.'}
                 </p>
               </div>
               <div className="who-tags" aria-label={locale === 'ar' ? 'مميزات مجموعة التجربة' : 'Discovery Set benefits'}>
-                <span className="who-tag">{locale === 'ar' ? '6 عينات من عطور نافَس' : '6 Nafas samples'}</span>
+                <span className="who-tag">{locale === 'ar' ? '6 عينات من عطور نفَس' : '6 Nafas samples'}</span>
                 <span className="who-tag">{locale === 'ar' ? 'مناسب لو محتار تختار أنهي عطر' : 'Useful when you are unsure which scent fits'}</span>
                 <span className="who-tag">{locale === 'ar' ? 'جرّب على بشرتك قبل الزجاجة الكبيرة' : 'Try on skin before the full bottle'}</span>
                 <span className="who-tag">{locale === 'ar' ? 'خطوة آمنة قبل شراء الحجم الكبير' : 'A safer step before the larger size'}</span>

--- a/frontend/src/utils/whatsapp.test.ts
+++ b/frontend/src/utils/whatsapp.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it } from 'vitest';
+import { buildProductWhatsAppMessage, buildProductWhatsAppUrl, buildWhatsAppUrl } from './whatsapp';
+import type { Product, Variant } from '../types/store';
+
+const product = {
+  id: 1,
+  name_ar: 'شرارة',
+  name_en: 'Sharara',
+  personality_ar: '',
+  personality_en: '',
+  slug: 'sharara',
+  story: '',
+  story_en: '',
+  notes_ar: [],
+  notes_en: [],
+  variants: [],
+} as Product;
+
+const variant = {
+  id: 11,
+  in_stock: true,
+  label: '50ml',
+  retail_price: 319,
+  size_ml: 50,
+  type: 'retail',
+} as Variant;
+
+describe('WhatsApp helpers', () => {
+  it('adds encoded text to a base WhatsApp URL', () => {
+    expect(buildWhatsAppUrl('أهلًا شرارة', 'https://wa.me/201000000000')).toBe(
+      'https://wa.me/201000000000?text=%D8%A3%D9%87%D9%84%D9%8B%D8%A7%20%D8%B4%D8%B1%D8%A7%D8%B1%D8%A9',
+    );
+  });
+
+  it('builds product-aware Arabic messages', () => {
+    const message = buildProductWhatsAppMessage({
+      locale: 'ar',
+      path: '/products/sharara',
+      product,
+      quantity: 2,
+      variant,
+    });
+
+    expect(message).toContain('شرارة');
+    expect(message).toContain('50ml');
+    expect(message).toMatch(/319|٣١٩/);
+    expect(message).toContain('الكمية: 2');
+    expect(message).toContain('/products/sharara');
+  });
+
+  it('returns an encoded product-aware URL', () => {
+    const url = buildProductWhatsAppUrl({
+      locale: 'ar',
+      path: '/products/sharara',
+      product,
+      quantity: 1,
+      variant,
+    }, 'https://wa.me/201000000000?source=product');
+
+    expect(url).toContain('https://wa.me/201000000000?source=product&text=');
+    expect(decodeURIComponent(url)).toContain('شرارة');
+  });
+});

--- a/frontend/src/utils/whatsapp.ts
+++ b/frontend/src/utils/whatsapp.ts
@@ -1,0 +1,52 @@
+import type { Product, Variant } from '../types/store';
+import { WHATSAPP_SUPPORT_URL } from './brand';
+import { formatCurrency } from './format';
+
+export function buildWhatsAppUrl(message: string, baseUrl = WHATSAPP_SUPPORT_URL) {
+  const trimmedBaseUrl = String(baseUrl || '').trim();
+
+  if (!trimmedBaseUrl) {
+    return '';
+  }
+
+  const encodedMessage = encodeURIComponent(message);
+
+  if (/[?&]text=/.test(trimmedBaseUrl)) {
+    return trimmedBaseUrl.replace(/([?&]text=)[^&]*/, `$1${encodedMessage}`);
+  }
+
+  const separator = trimmedBaseUrl.includes('?') ? '&' : '?';
+  return `${trimmedBaseUrl}${separator}text=${encodedMessage}`;
+}
+
+type ProductWhatsAppMessageInput = {
+  locale: 'ar' | 'en';
+  product: Product;
+  quantity: number;
+  variant: Variant;
+  path?: string;
+};
+
+export function buildProductWhatsAppMessage({
+  locale,
+  path,
+  product,
+  quantity,
+  variant,
+}: ProductWhatsAppMessageInput) {
+  const productName = locale === 'ar' ? product.name_ar || product.name_en : product.name_en || product.name_ar;
+  const variantLabel = variant.label || (variant.size_ml ? `${variant.size_ml}ml` : '');
+  const price = formatCurrency(variant.retail_price, locale);
+  const quantityText = locale === 'ar' ? `الكمية: ${quantity}` : `Quantity: ${quantity}`;
+  const pathText = path ? (locale === 'ar' ? ` الرابط: ${path}` : ` Link: ${path}`) : '';
+
+  if (locale === 'ar') {
+    return `أهلًا، عايز أسأل عن عطر ${productName} - مقاس ${variantLabel} بسعر ${price}. ${quantityText}.${pathText}`;
+  }
+
+  return `Hello, I want to ask about ${productName} - ${variantLabel} for ${price}. ${quantityText}.${pathText}`;
+}
+
+export function buildProductWhatsAppUrl(input: ProductWhatsAppMessageInput, baseUrl = WHATSAPP_SUPPORT_URL) {
+  return buildWhatsAppUrl(buildProductWhatsAppMessage(input), baseUrl);
+}


### PR DESCRIPTION
## Summary
- Adds a shared frontend WhatsApp helper for encoded support messages.
- Makes the Product Detail WhatsApp CTA product-aware with product name, selected variant/size, price, quantity, and product path.
- Adds light Product Detail conversion copy for Discovery Set, Try-first, and gift guidance without backend bundle logic.
- Polishes checkout payment microcopy while preserving Phase 0/1 payment behavior.

## Scope guard
- No homepage redesign.
- No AppleNafasHome, Navbar, Footer, or homepage CSS changes.
- No Paymob/online card changes.
- No Gift Boxes products, bundle engine, coupon UI, proof upload, loyalty points, or Phase 2B work.
- No formulas, costs, suppliers, or production percentages exposed publicly.

## Validation
- `npm run lint` passed.
- `npm run build` passed with the known large chunk warning.
- `npm test` passed: 9 files, 17 tests.
- `npm run test:responsive` passed: 25 tests.
- Browser QA passed for Product Detail add-to-cart, product-aware WhatsApp href, Discovery Set copy/CTA, checkout COD/Vodafone/Instapay visuals, order confirmation payment status/reference, and responsive overflow checks at 320/360/390/430/768/1024/1366/1440.

## Notes
- Browser QA used a temporary local Vite process with `VITE_WHATSAPP_URL` set only in process env for testing. No WhatsApp number was committed.