### PR TITLE
Phase 2B payment proof upload

### DIFF
--- a/backend/app/Http/Controllers/AdminOrderController.php
+++ b/backend/app/Http/Controllers/AdminOrderController.php
@@ -8,6 +8,7 @@ use App\Models\ProductVariant;
 use App\Services\OrderInventoryService;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Storage;
 
 class AdminOrderController extends Controller
 {
@@ -168,5 +169,16 @@ class AdminOrderController extends Controller
             'message' => "Payment {$validated['review_status']}",
             'order' => $order->fresh('items.variant.product', 'history', 'payment.reviewer'),
         ]);
+    }
+
+    public function downloadPaymentProof(Order $order)
+    {
+        $payment = $order->payment()->firstOrFail();
+
+        if (!$payment->proof_image_path || !Storage::disk('local')->exists($payment->proof_image_path)) {
+            abort(404, 'Payment proof not found');
+        }
+
+        return Storage::disk('local')->download($payment->proof_image_path);
     }
 }

--- a/backend/app/Http/Controllers/CheckoutController.php
+++ b/backend/app/Http/Controllers/CheckoutController.php
@@ -29,6 +29,7 @@ class CheckoutController extends Controller
             'payment_method' => 'required|string|in:cash_on_delivery,vodafone_cash,instapay',
             'payment_reference' => 'nullable|required_if:payment_method,vodafone_cash,instapay|string|max:255',
             'payment_payer_phone' => 'nullable|string|max:50',
+            'payment_proof' => 'nullable|prohibited_if:payment_method,cash_on_delivery|image|mimes:jpg,jpeg,png,webp|max:3072',
             'coupon_code' => 'nullable|string',
             'items' => 'required|array|min:1',
             'items.*.variant_id' => 'required|exists:product_variants,id',
@@ -136,6 +137,14 @@ class CheckoutController extends Controller
             }
 
             $isManualPayment = in_array($validated['payment_method'], ['vodafone_cash', 'instapay'], true);
+            $proofImagePath = null;
+
+            if ($isManualPayment && $request->hasFile('payment_proof')) {
+                $proofImagePath = $request->file('payment_proof')->store(
+                    'payment-proofs/' . $order->order_number,
+                    'local'
+                );
+            }
 
             Payment::create([
                 'order_id' => $order->id,
@@ -146,10 +155,12 @@ class CheckoutController extends Controller
                 'currency' => 'EGP',
                 'reference' => $isManualPayment ? ($validated['payment_reference'] ?? null) : 'COD-' . $order->order_number,
                 'payer_phone' => $validated['payment_payer_phone'] ?? null,
+                'proof_image_path' => $proofImagePath,
                 'review_status' => $isManualPayment ? 'pending' : null,
                 'provider_payload' => [
                     'source' => 'checkout',
                     'manual_review_required' => $isManualPayment,
+                    'proof_uploaded' => (bool) $proofImagePath,
                 ],
             ]);
 

--- a/backend/routes/api.php
+++ b/backend/routes/api.php
@@ -68,6 +68,7 @@ Route::middleware(['auth:sanctum', 'role'])->prefix('admin')->group(function () 
         Route::apiResource('orders', AdminOrderController::class);
         Route::patch('/orders/{id}/status', [AdminOrderController::class, 'updateStatus']);
         Route::patch('/orders/{order}/payment-review', [AdminOrderController::class, 'reviewPayment']);
+        Route::get('/orders/{order}/payment-proof', [AdminOrderController::class, 'downloadPaymentProof']);
         Route::apiResource('customers', \App\Http\Controllers\AdminCustomerController::class);
         Route::apiResource('coupons', \App\Http\Controllers\AdminCouponController::class);
     });

--- a/backend/tests/Feature/NafasE2ETest.php
+++ b/backend/tests/Feature/NafasE2ETest.php
@@ -12,7 +12,9 @@ use App\Models\Review;
 use App\Models\User;
 use App\Models\WholesaleInquiry;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Http\UploadedFile;
 use Illuminate\Support\Facades\Route;
+use Illuminate\Support\Facades\Storage;
 use Tests\TestCase;
 
 class NafasE2ETest extends TestCase
@@ -387,6 +389,114 @@ class NafasE2ETest extends TestCase
         $this->postJson('/api/checkout', $basePayload + [
             'payment_method' => 'bank_transfer',
         ])->assertUnprocessable();
+    }
+
+    public function test_manual_payment_checkout_accepts_valid_proof_image(): void
+    {
+        Storage::fake('local');
+        $variant = $this->activePublicVariant();
+
+        $response = $this->post('/api/checkout', [
+            'customer_name' => 'Proof Customer',
+            'phone' => '0123456789',
+            'address' => 'Detailed proof payment address',
+            'city' => 'Cairo',
+            'governorate' => 'Cairo',
+            'payment_method' => 'vodafone_cash',
+            'payment_reference' => 'VC-PROOF-1',
+            'payment_proof' => UploadedFile::fake()->image('proof.webp')->size(256),
+            'items' => [['variant_id' => $variant->id, 'quantity' => 1]],
+        ]);
+
+        $response->assertCreated()
+            ->assertJsonPath('order.payment.status', 'pending_review')
+            ->assertJsonPath('order.payment.method', 'vodafone_cash');
+
+        $proofPath = $response->json('order.payment.proof_image_path');
+        $this->assertNotEmpty($proofPath);
+        $this->assertStringStartsWith('payment-proofs/', $proofPath);
+        Storage::disk('local')->assertExists($proofPath);
+    }
+
+    public function test_manual_payment_checkout_rejects_invalid_proof_file_type(): void
+    {
+        Storage::fake('local');
+        $variant = $this->activePublicVariant();
+
+        $this->withHeader('Accept', 'application/json')->post('/api/checkout', [
+            'customer_name' => 'Bad Proof',
+            'phone' => '0123456789',
+            'address' => 'Detailed proof payment address',
+            'city' => 'Cairo',
+            'governorate' => 'Cairo',
+            'payment_method' => 'instapay',
+            'payment_reference' => 'IP-BAD-1',
+            'payment_proof' => UploadedFile::fake()->create('proof.txt', 20, 'text/plain'),
+            'items' => [['variant_id' => $variant->id, 'quantity' => 1]],
+        ])->assertUnprocessable()
+            ->assertJsonValidationErrors('payment_proof');
+    }
+
+    public function test_manual_payment_checkout_rejects_oversized_proof_file(): void
+    {
+        Storage::fake('local');
+        $variant = $this->activePublicVariant();
+
+        $this->withHeader('Accept', 'application/json')->post('/api/checkout', [
+            'customer_name' => 'Large Proof',
+            'phone' => '0123456789',
+            'address' => 'Detailed proof payment address',
+            'city' => 'Cairo',
+            'governorate' => 'Cairo',
+            'payment_method' => 'vodafone_cash',
+            'payment_reference' => 'VC-LARGE-1',
+            'payment_proof' => UploadedFile::fake()->image('proof.jpg')->size(3073),
+            'items' => [['variant_id' => $variant->id, 'quantity' => 1]],
+        ])->assertUnprocessable()
+            ->assertJsonValidationErrors('payment_proof');
+    }
+
+    public function test_cod_checkout_rejects_payment_proof_upload(): void
+    {
+        Storage::fake('local');
+        $variant = $this->activePublicVariant();
+
+        $this->withHeader('Accept', 'application/json')->post('/api/checkout', [
+            'customer_name' => 'COD Proof',
+            'phone' => '0123456789',
+            'address' => 'Detailed cod payment address',
+            'city' => 'Cairo',
+            'governorate' => 'Cairo',
+            'payment_method' => 'cash_on_delivery',
+            'payment_proof' => UploadedFile::fake()->image('proof.png')->size(128),
+            'items' => [['variant_id' => $variant->id, 'quantity' => 1]],
+        ])->assertUnprocessable()
+            ->assertJsonValidationErrors('payment_proof');
+    }
+
+    public function test_admin_can_download_manual_payment_proof_but_public_cannot(): void
+    {
+        Storage::fake('local');
+        $variant = $this->activePublicVariant();
+        $token = $this->loginAsRole('order_manager');
+
+        $orderId = $this->post('/api/checkout', [
+            'customer_name' => 'Download Proof',
+            'phone' => '0123456789',
+            'address' => 'Detailed proof payment address',
+            'city' => 'Cairo',
+            'governorate' => 'Cairo',
+            'payment_method' => 'instapay',
+            'payment_reference' => 'IP-DOWNLOAD-1',
+            'payment_proof' => UploadedFile::fake()->image('proof.png')->size(128),
+            'items' => [['variant_id' => $variant->id, 'quantity' => 1]],
+        ])->assertCreated()->json('order.id');
+
+        $this->getJson("/api/admin/orders/{$orderId}/payment-proof")->assertUnauthorized();
+
+        $this->withHeader('Authorization', 'Bearer ' . $token)
+            ->get("/api/admin/orders/{$orderId}/payment-proof")
+            ->assertOk();
     }
 
     public function test_manual_payment_review_can_be_approved_by_order_admin(): void

--- a/frontend/src/api/adminApi.ts
+++ b/frontend/src/api/adminApi.ts
@@ -23,6 +23,7 @@ export const adminApi = {
     update: (id: number | string, data: unknown) => client.patch(`/admin/orders/${id}`, data),
     updateStatus: (id: number | string, status: string, notes?: string) => client.patch(`/admin/orders/${id}/status`, { status, notes }),
     reviewPayment: (id: number | string, data: unknown) => client.patch(`/admin/orders/${id}/payment-review`, data),
+    downloadPaymentProof: (id: number | string) => client.get(`/admin/orders/${id}/payment-proof`, { responseType: 'blob' }),
   },
   formulas: {
     list: () => client.get('/admin/formulas'),

--- a/frontend/src/pages/Checkout.tsx
+++ b/frontend/src/pages/Checkout.tsx
@@ -4,7 +4,7 @@ import { publicApi } from '../api/publicApi';
 import ProductMedia from '../components/ProductMedia';
 import { useLocale } from '../context/LocaleContext';
 import { useCart } from '../hooks/useCart';
-import { buildCheckoutPayload } from '../utils/checkout';
+import { buildCheckoutPayload, validatePaymentProof } from '../utils/checkout';
 import { formatCurrency } from '../utils/format';
 import { normalizeOrder } from '../utils/orders';
 
@@ -20,6 +20,7 @@ export default function Checkout() {
   const navigate = useNavigate();
   const [error, setError] = useState('');
   const [submitting, setSubmitting] = useState(false);
+  const [paymentProof, setPaymentProof] = useState<File | null>(null);
   const [touched, setTouched] = useState<Record<string, boolean>>({});
   const [errors, setErrors] = useState<Record<string, string>>({});
   const [form, setForm] = useState({
@@ -34,6 +35,7 @@ export default function Checkout() {
     payment_reference: '',
     payment_payer_phone: '',
   });
+  const paymentProofError = errors.payment_proof || '';
 
   const validateField = (name: string, value: string) => {
     switch (name) {
@@ -68,15 +70,18 @@ export default function Checkout() {
     setForm((current) => ({ ...current, payment_method: paymentMethod }));
 
     if (paymentMethod === 'cash_on_delivery') {
+      setPaymentProof(null);
       setErrors((current) => ({
         ...current,
         payment_reference: '',
         payment_payer_phone: '',
+        payment_proof: '',
       }));
       setTouched((current) => ({
         ...current,
         payment_reference: false,
         payment_payer_phone: false,
+        payment_proof: false,
       }));
     }
   };
@@ -111,6 +116,7 @@ export default function Checkout() {
           address: validateField('address', form.address),
           payment_reference: validateField('payment_reference', form.payment_reference),
           payment_payer_phone: validateField('payment_payer_phone', form.payment_payer_phone),
+          payment_proof: form.payment_method === 'cash_on_delivery' ? '' : validatePaymentProof(paymentProof, locale),
         };
         setErrors(nextErrors);
         setTouched({
@@ -122,6 +128,7 @@ export default function Checkout() {
           address: true,
           payment_reference: true,
           payment_payer_phone: true,
+          payment_proof: true,
         });
         if (Object.values(nextErrors).some(Boolean)) {
           return;
@@ -131,7 +138,7 @@ export default function Checkout() {
         setError('');
         try {
           await publicApi.validateCart(items.map((item) => ({ quantity: item.quantity, variant_id: item.variant.id })));
-          const payload = buildCheckoutPayload(form, items);
+          const payload = buildCheckoutPayload({ ...form, payment_proof: paymentProof }, items);
           const response = await publicApi.checkout(payload);
           const order = normalizeOrder(response.data.order);
           sessionStorage.setItem(`order_${order.order_number}`, JSON.stringify(order));
@@ -312,9 +319,38 @@ export default function Checkout() {
                 </label>
                 <small className="field-hint is-wide">
                   {locale === 'ar'
-                    ? 'بعد التحويل، اكتب رقم العملية أو المرجع فقط. رفع صورة إثبات الدفع غير مفعل في هذه المرحلة، وسيُراجع الفريق التحويل يدويًا.'
-                    : 'After transferring, enter the transaction reference only. Proof image upload is not enabled in this phase, and the team will review the transfer manually.'}
+                    ? 'بعد التحويل، اكتب رقم العملية أو المرجع. يمكنك رفع صورة إثبات الدفع اختياريًا لمساعدة الفريق في المراجعة اليدوية.'
+                    : 'After transferring, enter the transaction reference. You can optionally upload a proof image to help the team review payment manually.'}
                 </small>
+                <label className={`is-wide ${paymentProofError && touched.payment_proof ? 'has-error' : ''}`}>
+                  <span>{locale === 'ar' ? 'صورة إثبات الدفع (اختياري)' : 'Payment proof image (optional)'}</span>
+                  <input
+                    type="file"
+                    accept="image/jpeg,image/png,image/webp"
+                    onBlur={() => setTouched((current) => ({ ...current, payment_proof: true }))}
+                    onChange={(event) => {
+                      const file = event.target.files?.[0] || null;
+                      const message = validatePaymentProof(file, locale);
+                      setPaymentProof(message ? null : file);
+                      setTouched((current) => ({ ...current, payment_proof: true }));
+                      setErrors((current) => ({ ...current, payment_proof: message }));
+                      if (message) {
+                        event.target.value = '';
+                      }
+                    }}
+                  />
+                  {paymentProof ? (
+                    <small className="field-hint">
+                      {locale === 'ar' ? `تم اختيار: ${paymentProof.name}` : `Selected: ${paymentProof.name}`}
+                    </small>
+                  ) : null}
+                  {paymentProofError && touched.payment_proof ? <small className="field-error">{paymentProofError}</small> : null}
+                  <small className="field-hint">
+                    {locale === 'ar'
+                      ? 'الصيغ المقبولة: JPG أو PNG أو WEBP. الحد الأقصى 3MB.'
+                      : 'Accepted formats: JPG, PNG, or WEBP. Maximum size 3MB.'}
+                  </small>
+                </label>
               </div>
             ) : null}
           </section>

--- a/frontend/src/pages/Checkout.tsx
+++ b/frontend/src/pages/Checkout.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useState } from 'react';
+import { useMemo, useRef, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { publicApi } from '../api/publicApi';
 import ProductMedia from '../components/ProductMedia';
@@ -21,6 +21,7 @@ export default function Checkout() {
   const [error, setError] = useState('');
   const [submitting, setSubmitting] = useState(false);
   const [paymentProof, setPaymentProof] = useState<File | null>(null);
+  const paymentProofInputRef = useRef<HTMLInputElement | null>(null);
   const [touched, setTouched] = useState<Record<string, boolean>>({});
   const [errors, setErrors] = useState<Record<string, string>>({});
   const [form, setForm] = useState({
@@ -83,6 +84,16 @@ export default function Checkout() {
         payment_payer_phone: false,
         payment_proof: false,
       }));
+    }
+  };
+
+  const clearPaymentProof = () => {
+    setPaymentProof(null);
+    setErrors((current) => ({ ...current, payment_proof: '' }));
+    setTouched((current) => ({ ...current, payment_proof: false }));
+
+    if (paymentProofInputRef.current) {
+      paymentProofInputRef.current.value = '';
     }
   };
 
@@ -325,6 +336,7 @@ export default function Checkout() {
                 <label className={`is-wide ${paymentProofError && touched.payment_proof ? 'has-error' : ''}`}>
                   <span>{locale === 'ar' ? 'صورة إثبات الدفع (اختياري)' : 'Payment proof image (optional)'}</span>
                   <input
+                    ref={paymentProofInputRef}
                     type="file"
                     accept="image/jpeg,image/png,image/webp"
                     onBlur={() => setTouched((current) => ({ ...current, payment_proof: true }))}
@@ -345,6 +357,11 @@ export default function Checkout() {
                     </small>
                   ) : null}
                   {paymentProofError && touched.payment_proof ? <small className="field-error">{paymentProofError}</small> : null}
+                  {paymentProofError ? (
+                    <button type="button" className="text-button" onClick={clearPaymentProof}>
+                      {locale === 'ar' ? 'المتابعة بدون صورة إثبات' : 'Continue without proof image'}
+                    </button>
+                  ) : null}
                   <small className="field-hint">
                     {locale === 'ar'
                       ? 'الصيغ المقبولة: JPG أو PNG أو WEBP. الحد الأقصى 3MB.'

--- a/frontend/src/pages/admin/AdminOrderDetail.tsx
+++ b/frontend/src/pages/admin/AdminOrderDetail.tsx
@@ -30,6 +30,16 @@ const AdminOrderDetail: React.FC = () => {
   };
   const canReviewPayment = ['vodafone_cash', 'instapay'].includes(payment?.method || payment?.provider);
 
+  const downloadPaymentProof = async () => {
+    const res = await adminApi.orders.downloadPaymentProof(id);
+    const url = window.URL.createObjectURL(res.data);
+    const link = document.createElement('a');
+    link.href = url;
+    link.download = `payment-proof-${order.order_number}`;
+    link.click();
+    window.URL.revokeObjectURL(url);
+  };
+
   const reviewPayment = async (reviewStatus: 'approved' | 'rejected') => {
     const res = await adminApi.orders.reviewPayment(id, {
       review_status: reviewStatus,
@@ -70,7 +80,19 @@ const AdminOrderDetail: React.FC = () => {
               <div className="data-card__row"><span className="data-card__label">الحالة</span><Badge tone={payment.status === 'approved' ? 'success' : payment.status === 'rejected' ? 'danger' : 'gold'}>{formatStatus(payment.status)}</Badge></div>
               {payment.reference ? <div className="data-card__row"><span className="data-card__label">رقم العملية</span><span>{payment.reference}</span></div> : null}
               {payment.payer_phone ? <div className="data-card__row"><span className="data-card__label">هاتف المحوّل</span><span>{payment.payer_phone}</span></div> : null}
-              {payment.proof_image_path ? <div className="data-card__row"><span className="data-card__label">إثبات الدفع</span><span>{payment.proof_image_path}</span></div> : null}
+              {payment.proof_image_path ? (
+                <div className="stack">
+                  <strong>إثبات الدفع</strong>
+                  <div className="data-card__row">
+                    <span className="data-card__label">المسار المخزن</span>
+                    <span style={{ overflowWrap: 'anywhere', textAlign: 'end' }}>{payment.proof_image_path}</span>
+                  </div>
+                  <Button variant="ghost" onClick={downloadPaymentProof}>تحميل إثبات الدفع</Button>
+                  <small className="copy-muted">رابط الإثبات محمي للأدمن فقط، ولا يتم عرضه كرابط عام للعملاء.</small>
+                </div>
+              ) : (
+                canReviewPayment ? <small className="copy-muted">لا توجد صورة إثبات مرفوعة. راجع رقم العملية مع بيانات التحويل يدويًا.</small> : null
+              )}
               {canReviewPayment ? (
                 <>
                   <Textarea value={paymentNote} onChange={(event) => setPaymentNote(event.target.value)} placeholder="ملاحظة مراجعة الدفع" />

--- a/frontend/src/pages/admin/AdminOrderDetail.tsx
+++ b/frontend/src/pages/admin/AdminOrderDetail.tsx
@@ -10,6 +10,7 @@ const AdminOrderDetail: React.FC = () => {
   const [notes, setNotes] = useState('');
   const [paymentNote, setPaymentNote] = useState('');
   const [error, setError] = useState('');
+  const [proofError, setProofError] = useState('');
 
   useEffect(() => {
     adminApi.orders.get(id).then((res) => {
@@ -31,13 +32,18 @@ const AdminOrderDetail: React.FC = () => {
   const canReviewPayment = ['vodafone_cash', 'instapay'].includes(payment?.method || payment?.provider);
 
   const downloadPaymentProof = async () => {
-    const res = await adminApi.orders.downloadPaymentProof(id);
-    const url = window.URL.createObjectURL(res.data);
-    const link = document.createElement('a');
-    link.href = url;
-    link.download = `payment-proof-${order.order_number}`;
-    link.click();
-    window.URL.revokeObjectURL(url);
+    setProofError('');
+    try {
+      const res = await adminApi.orders.downloadPaymentProof(id);
+      const url = window.URL.createObjectURL(res.data);
+      const link = document.createElement('a');
+      link.href = url;
+      link.download = `payment-proof-${order.order_number}`;
+      link.click();
+      window.URL.revokeObjectURL(url);
+    } catch {
+      setProofError('تعذّر تحميل إثبات الدفع. تأكد من وجود الملف أو راجع التخزين.');
+    }
   };
 
   const reviewPayment = async (reviewStatus: 'approved' | 'rejected') => {
@@ -88,6 +94,7 @@ const AdminOrderDetail: React.FC = () => {
                     <span style={{ overflowWrap: 'anywhere', textAlign: 'end' }}>{payment.proof_image_path}</span>
                   </div>
                   <Button variant="ghost" onClick={downloadPaymentProof}>تحميل إثبات الدفع</Button>
+                  {proofError ? <small className="ui-field-message ui-field-message--error">{proofError}</small> : null}
                   <small className="copy-muted">رابط الإثبات محمي للأدمن فقط، ولا يتم عرضه كرابط عام للعملاء.</small>
                 </div>
               ) : (

--- a/frontend/src/utils/checkout.test.ts
+++ b/frontend/src/utils/checkout.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { buildCheckoutPayload } from './checkout';
+import { buildCheckoutPayload, validatePaymentProof } from './checkout';
 
 describe('buildCheckoutPayload', () => {
   it('builds backend-safe payload from cart items', () => {
@@ -25,5 +25,30 @@ describe('buildCheckoutPayload', () => {
       items: [{ variant_id: 8, quantity: 1 }],
     });
     expect(payload).not.toHaveProperty('payment_reference');
+  });
+
+  it('builds multipart payload when a payment proof is attached', () => {
+    const proof = new File(['proof'], 'proof.webp', { type: 'image/webp' });
+    const payload = buildCheckoutPayload({
+      customer_name: 'Ahmed',
+      payment_method: 'instapay',
+      payment_proof: proof,
+      payment_reference: 'IP-1',
+    }, [
+      { variant: { id: 9 }, quantity: 1 },
+    ]);
+
+    expect(payload).toBeInstanceOf(FormData);
+    expect((payload as FormData).get('payment_method')).toBe('instapay');
+    expect((payload as FormData).get('items[0][variant_id]')).toBe('9');
+    expect((payload as FormData).get('payment_proof')).toBe(proof);
+  });
+
+  it('validates manual payment proof file type and size', () => {
+    expect(validatePaymentProof(new File(['ok'], 'proof.png', { type: 'image/png' }))).toBe('');
+    expect(validatePaymentProof(new File(['bad'], 'proof.txt', { type: 'text/plain' }))).toContain('JPG');
+
+    const oversized = new File([new Uint8Array((3 * 1024 * 1024) + 1)], 'proof.jpg', { type: 'image/jpeg' });
+    expect(validatePaymentProof(oversized)).toContain('3MB');
   });
 });

--- a/frontend/src/utils/checkout.ts
+++ b/frontend/src/utils/checkout.ts
@@ -1,4 +1,54 @@
-export const buildCheckoutPayload = (form: Record<string, unknown>, items: Array<{ variant: { id: number }; quantity: number }>) => ({
-  ...form,
-  items: items.map((item) => ({ variant_id: item.variant.id, quantity: item.quantity })),
-});
+export const PAYMENT_PROOF_MAX_BYTES = 3 * 1024 * 1024;
+export const PAYMENT_PROOF_ACCEPTED_TYPES = ['image/jpeg', 'image/png', 'image/webp'];
+
+export function validatePaymentProof(file: File | null | undefined, locale: 'ar' | 'en' = 'ar') {
+  if (!file) {
+    return '';
+  }
+
+  if (!PAYMENT_PROOF_ACCEPTED_TYPES.includes(file.type)) {
+    return locale === 'ar'
+      ? 'ارفع صورة بصيغة JPG أو PNG أو WEBP فقط.'
+      : 'Upload a JPG, PNG, or WEBP image only.';
+  }
+
+  if (file.size > PAYMENT_PROOF_MAX_BYTES) {
+    return locale === 'ar'
+      ? 'حجم صورة إثبات الدفع يجب ألا يتجاوز 3MB.'
+      : 'Payment proof image must be 3MB or smaller.';
+  }
+
+  return '';
+}
+
+export const buildCheckoutPayload = (form: Record<string, unknown>, items: Array<{ variant: { id: number }; quantity: number }>) => {
+  const normalizedItems = items.map((item) => ({ variant_id: item.variant.id, quantity: item.quantity }));
+  const paymentProof = form.payment_proof;
+
+  if (paymentProof instanceof File) {
+    const formData = new FormData();
+
+    Object.entries(form).forEach(([key, value]) => {
+      if (key === 'payment_proof') {
+        return;
+      }
+
+      if (value !== undefined && value !== null && value !== '') {
+        formData.append(key, String(value));
+      }
+    });
+
+    normalizedItems.forEach((item, index) => {
+      formData.append(`items[${index}][variant_id]`, String(item.variant_id));
+      formData.append(`items[${index}][quantity]`, String(item.quantity));
+    });
+    formData.append('payment_proof', paymentProof);
+
+    return formData;
+  }
+
+  return {
+    ...Object.fromEntries(Object.entries(form).filter(([key]) => key !== 'payment_proof')),
+    items: normalizedItems,
+  };
+};


### PR DESCRIPTION
## Summary
- Enables optional proof image upload for Vodafone Cash and Instapay checkout only.
- Keeps COD checkout free of proof upload fields and rejects COD proof files server-side.
- Validates proof images as jpg/jpeg/png/webp with a 3MB limit.
- Stores proof files on Laravel's private local disk under `payment-proofs/{order_number}` and saves the path to `payments.proof_image_path`.
- Adds protected admin download access for payment proofs.
- Updates admin order detail to show proof path, protected-download action, and manual review copy.

## Scope guard
- No homepage, AppleNafasHome, Navbar, Footer, or homepage CSS changes.
- No product catalog, prices, seeders, formulas, costs, or supplier changes.
- No Paymob / online card.
- No Gift Boxes, bundle engine, coupons, loyalty, or Try & Buy backend logic.

## Validation
- `npm run lint` passed.
- `npm run build` passed with the known large chunk warning.
- `npm test` passed: 9 files, 19 tests.
- `npm run test:responsive` passed: 25 tests.
- `php artisan test` passed: 35 tests, 147 assertions.
- `php artisan route:list --path=admin/orders` confirmed `GET api/admin/orders/{order}/payment-proof`.

## Browser QA
- COD checkout: no proof field visible, order submitted.
- Vodafone Cash: proof field visible, invalid file rejected, valid image selected/submitted, confirmation pending review.
- Instapay: valid image selected/submitted, confirmation pending review.
- Admin order detail: reference and proof info visible for manual payments.
- Admin approve/reject still works.
- Responsive checks passed at 320/360/390/430/768/1024/1366/1440 for Checkout, Order confirmation, and Admin order detail.

## Notes
- Proof download is protected through the admin API using auth headers; proofs are not exposed as public URLs.