### PR TITLE
Fix cart response sanitization

### DIFF
--- a/backend/app/Http/Controllers/CartController.php
+++ b/backend/app/Http/Controllers/CartController.php
@@ -2,6 +2,8 @@
 
 namespace App\Http\Controllers;
 
+use App\Http\Resources\CartItemResource;
+use App\Http\Resources\CartResource;
 use App\Models\CartItem;
 use App\Models\ProductVariant;
 use App\Services\CartService;
@@ -12,7 +14,7 @@ class CartController extends Controller
     public function show(Request $request, CartService $cartService)
     {
         $cart = $cartService->resolveCart($request->user(), $request->header('X-Session-Key'));
-        return response()->json($cart->load('items.variant.product'));
+        return response()->json(new CartResource($cart->load('items.variant.product')));
     }
 
     public function add(Request $request, CartService $cartService)
@@ -38,7 +40,7 @@ class CartController extends Controller
             ['quantity' => $validated['quantity'], 'snapshot_price' => $variant->retail_price]
         );
 
-        return response()->json($cart->fresh('items.variant.product'), 201);
+        return response()->json(new CartResource($cart->fresh('items.variant.product')), 201);
     }
 
     public function update(Request $request, CartService $cartService, CartItem $cartItem)
@@ -65,7 +67,7 @@ class CartController extends Controller
             'snapshot_price' => $variant->retail_price,
         ]);
 
-        return response()->json($cartItem->load('variant.product'));
+        return response()->json(new CartItemResource($cartItem->load('variant.product')));
     }
 
     public function destroy(Request $request, CartService $cartService, CartItem $cartItem)
@@ -94,6 +96,6 @@ class CartController extends Controller
             'items.*.quantity' => ['required', 'integer', 'min:1'],
         ]);
 
-        return response()->json($cartService->mergeGuestCart($request->user(), $validated['items']));
+        return response()->json(new CartResource($cartService->mergeGuestCart($request->user(), $validated['items'])));
     }
 }

--- a/backend/app/Http/Resources/CartItemResource.php
+++ b/backend/app/Http/Resources/CartItemResource.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace App\Http\Resources;
+
+use Illuminate\Http\Request;
+use Illuminate\Http\Resources\Json\JsonResource;
+
+class CartItemResource extends JsonResource
+{
+    public function toArray(Request $request): array
+    {
+        return [
+            'id' => $this->id,
+            'quantity' => (int) $this->quantity,
+            'snapshot_price' => $this->snapshot_price,
+            'variant' => new ProductVariantResource($this->whenLoaded('variant')),
+        ];
+    }
+}

--- a/backend/app/Http/Resources/CartItemResource.php
+++ b/backend/app/Http/Resources/CartItemResource.php
@@ -9,11 +9,31 @@ class CartItemResource extends JsonResource
 {
     public function toArray(Request $request): array
     {
+        $variant = $this->whenLoaded('variant');
+        $product = $variant?->relationLoaded('product') ? $variant->product : null;
+
         return [
             'id' => $this->id,
             'quantity' => (int) $this->quantity,
             'snapshot_price' => $this->snapshot_price,
-            'variant' => new ProductVariantResource($this->whenLoaded('variant')),
+            'variant' => $variant ? [
+                'id' => $variant->id,
+                'sku' => $variant->sku,
+                'size_ml' => $variant->size_ml,
+                'label' => $variant->label,
+                'retail_price' => $variant->retail_price,
+                'in_stock' => $variant->stock_quantity > 0,
+                'product' => $product ? [
+                    'id' => $product->id,
+                    'code' => $product->code,
+                    'slug' => $product->slug,
+                    'name_ar' => $product->name_ar,
+                    'name_en' => $product->name_en,
+                    'gender' => $product->gender,
+                    'marketing_line_ar' => $product->marketing_line_ar,
+                    'marketing_line_en' => $product->marketing_line_en,
+                ] : null,
+            ] : null,
         ];
     }
 }

--- a/backend/app/Http/Resources/CartResource.php
+++ b/backend/app/Http/Resources/CartResource.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace App\Http\Resources;
+
+use Illuminate\Http\Request;
+use Illuminate\Http\Resources\Json\JsonResource;
+
+class CartResource extends JsonResource
+{
+    public function toArray(Request $request): array
+    {
+        $items = $this->whenLoaded('items', fn () => $this->items
+            ->filter(fn ($item) => $item->variant
+                && $item->variant->is_active
+                && $item->variant->product
+                && $item->variant->product->status === 'active')
+            ->values());
+
+        return [
+            'id' => $this->id,
+            'items' => CartItemResource::collection($items),
+        ];
+    }
+}

--- a/backend/app/Http/Resources/ProductVariantResource.php
+++ b/backend/app/Http/Resources/ProductVariantResource.php
@@ -21,7 +21,6 @@ class ProductVariantResource extends JsonResource
             'is_tester' => (bool) $this->is_tester,
             'is_ball_oil_only' => (bool) $this->is_ball_oil_only,
             'type' => $this->is_tester ? 'tester' : 'retail',
-            'product' => new ProductResource($this->whenLoaded('product')),
         ];
     }
 }

--- a/backend/app/Http/Resources/ProductVariantResource.php
+++ b/backend/app/Http/Resources/ProductVariantResource.php
@@ -21,6 +21,7 @@ class ProductVariantResource extends JsonResource
             'is_tester' => (bool) $this->is_tester,
             'is_ball_oil_only' => (bool) $this->is_ball_oil_only,
             'type' => $this->is_tester ? 'tester' : 'retail',
+            'product' => new ProductResource($this->whenLoaded('product')),
         ];
     }
 }

--- a/backend/app/Services/CartService.php
+++ b/backend/app/Services/CartService.php
@@ -23,8 +23,8 @@ class CartService
         $cart = $this->resolveCart($user);
 
         foreach ($items as $item) {
-            $variant = ProductVariant::find($item['variant_id'] ?? null);
-            if (!$variant) {
+            $variant = ProductVariant::with('product')->find($item['variant_id'] ?? null);
+            if (!$variant || !$variant->is_active || !$variant->product || $variant->product->status !== 'active') {
                 continue;
             }
 

--- a/backend/tests/Feature/NafasE2ETest.php
+++ b/backend/tests/Feature/NafasE2ETest.php
@@ -118,6 +118,11 @@ class NafasE2ETest extends TestCase
             'admin_note',
             'admin_notes',
             'reviewed_by',
+            'stock_quantity',
+            'is_active',
+            'is_tester',
+            'is_ball_oil_only',
+            'type',
         ] as $forbiddenField) {
             $this->assertStringNotContainsString(
                 "\"{$forbiddenField}\"",

--- a/backend/tests/Feature/NafasE2ETest.php
+++ b/backend/tests/Feature/NafasE2ETest.php
@@ -3,6 +3,8 @@
 namespace Tests\Feature;
 
 use App\Models\ContactInquiry;
+use App\Models\Cart;
+use App\Models\CartItem;
 use App\Models\Coupon;
 use App\Models\Customer;
 use App\Models\Formula;
@@ -92,6 +94,35 @@ class NafasE2ETest extends TestCase
                 "\"{$forbiddenField}\"",
                 $json,
                 "Public order payload leaked {$forbiddenField}."
+            );
+        }
+    }
+
+    private function assertPublicCartPayloadIsSanitized(array $payload): void
+    {
+        $json = json_encode($payload);
+
+        foreach ([
+            'cost_price',
+            'wholesale_price',
+            'oil_percentage',
+            'alcohol_percentage',
+            'cost_material_per_bottle',
+            'cost_packaging_per_bottle',
+            'cost_filling_per_bottle',
+            'formula',
+            'ingredients',
+            'supplier',
+            'provider_payload',
+            'proof_image_path',
+            'admin_note',
+            'admin_notes',
+            'reviewed_by',
+        ] as $forbiddenField) {
+            $this->assertStringNotContainsString(
+                "\"{$forbiddenField}\"",
+                $json,
+                "Public cart payload leaked {$forbiddenField}."
             );
         }
     }
@@ -234,6 +265,128 @@ class NafasE2ETest extends TestCase
         $cartItemId = $cart->json('items.0.id');
         $this->patchJson("/api/cart/items/{$cartItemId}", ['quantity' => 3], ['X-Session-Key' => 'session-1'])->assertOk();
         $this->deleteJson("/api/cart/items/{$cartItemId}", [], ['X-Session-Key' => 'session-1'])->assertOk();
+    }
+
+    public function test_get_cart_response_is_sanitized(): void
+    {
+        $variant = $this->activePublicVariant();
+
+        $this->postJson('/api/cart/items', ['variant_id' => $variant->id, 'quantity' => 2], ['X-Session-Key' => 'cart-safe-get'])
+            ->assertCreated();
+
+        $response = $this->getJson('/api/cart', ['X-Session-Key' => 'cart-safe-get'])
+            ->assertOk()
+            ->assertJsonPath('items.0.quantity', 2);
+
+        $this->assertPublicCartPayloadIsSanitized($response->json());
+        $response->assertJsonMissingPath('items.0.variant.cost_price')
+            ->assertJsonMissingPath('items.0.variant.oil_percentage')
+            ->assertJsonMissingPath('items.0.variant.product.cost_material_per_bottle');
+    }
+
+    public function test_add_cart_item_response_is_sanitized(): void
+    {
+        $variant = $this->activePublicVariant();
+
+        $response = $this->postJson('/api/cart/items', ['variant_id' => $variant->id, 'quantity' => 1], ['X-Session-Key' => 'cart-safe-add'])
+            ->assertCreated()
+            ->assertJsonPath('items.0.variant.id', $variant->id);
+
+        $this->assertPublicCartPayloadIsSanitized($response->json());
+    }
+
+    public function test_update_cart_item_response_is_sanitized(): void
+    {
+        $variant = $this->activePublicVariant();
+
+        $this->postJson('/api/cart/items', ['variant_id' => $variant->id, 'quantity' => 1], ['X-Session-Key' => 'cart-safe-update'])
+            ->assertCreated();
+
+        $cartItemId = $this->getJson('/api/cart', ['X-Session-Key' => 'cart-safe-update'])->json('items.0.id');
+
+        $response = $this->patchJson("/api/cart/items/{$cartItemId}", ['quantity' => 3], ['X-Session-Key' => 'cart-safe-update'])
+            ->assertOk()
+            ->assertJsonPath('quantity', 3);
+
+        $this->assertPublicCartPayloadIsSanitized($response->json());
+    }
+
+    public function test_merge_cart_response_is_sanitized(): void
+    {
+        $variant = $this->activePublicVariant();
+        $user = User::factory()->create(['role' => 'customer', 'password' => bcrypt('password123')]);
+        $token = $this->postJson('/api/auth/login', ['email' => $user->email, 'password' => 'password123'])->json('token');
+
+        $response = $this->withHeader('Authorization', 'Bearer ' . $token)
+            ->postJson('/api/cart/merge', [
+                'items' => [['variant_id' => $variant->id, 'quantity' => 2]],
+            ])
+            ->assertOk()
+            ->assertJsonPath('items.0.quantity', 2);
+
+        $this->assertPublicCartPayloadIsSanitized($response->json());
+    }
+
+    public function test_hidden_product_details_do_not_leak_in_cart_responses(): void
+    {
+        $publicVariant = $this->activePublicVariant();
+        $hiddenProduct = Product::factory()->create([
+            'code' => 'RND-HIDDEN',
+            'slug' => 'hidden-rnd-cart',
+            'name_ar' => 'Hidden R&D',
+            'name_en' => 'Hidden R&D',
+            'gender' => 'Unisex',
+            'status' => 'draft',
+            'cost_material_per_bottle' => 123,
+            'cost_packaging_per_bottle' => 45,
+            'cost_filling_per_bottle' => 67,
+        ]);
+        $hiddenVariant = ProductVariant::create([
+            'product_id' => $hiddenProduct->id,
+            'sku' => 'RND-HIDDEN-30',
+            'size_ml' => 30,
+            'retail_price' => 999,
+            'stock_quantity' => 10,
+            'is_active' => true,
+            'cost_price' => 111,
+            'wholesale_price' => 222,
+            'oil_percentage' => 33,
+            'alcohol_percentage' => 67,
+        ]);
+
+        $cart = Cart::firstOrCreate(['session_key' => 'cart-hidden-safe']);
+        CartItem::create([
+            'cart_id' => $cart->id,
+            'product_variant_id' => $hiddenVariant->id,
+            'quantity' => 1,
+            'snapshot_price' => $hiddenVariant->retail_price,
+        ]);
+
+        $response = $this->getJson('/api/cart', ['X-Session-Key' => 'cart-hidden-safe'])
+            ->assertOk()
+            ->assertJsonCount(0, 'items');
+
+        $json = json_encode($response->json());
+        $this->assertStringNotContainsString('hidden-rnd-cart', $json);
+        $this->assertStringNotContainsString('RND-HIDDEN', $json);
+        $this->assertPublicCartPayloadIsSanitized($response->json());
+
+        $user = User::factory()->create(['role' => 'customer', 'password' => bcrypt('password123')]);
+        $token = $this->postJson('/api/auth/login', ['email' => $user->email, 'password' => 'password123'])->json('token');
+        $merge = $this->withHeader('Authorization', 'Bearer ' . $token)
+            ->postJson('/api/cart/merge', [
+                'items' => [
+                    ['variant_id' => $hiddenVariant->id, 'quantity' => 1],
+                    ['variant_id' => $publicVariant->id, 'quantity' => 1],
+                ],
+            ])
+            ->assertOk()
+            ->assertJsonCount(1, 'items');
+
+        $mergeJson = json_encode($merge->json());
+        $this->assertStringNotContainsString('hidden-rnd-cart', $mergeJson);
+        $this->assertStringNotContainsString('RND-HIDDEN', $mergeJson);
+        $this->assertPublicCartPayloadIsSanitized($merge->json());
     }
 
     public function test_guest_session_cannot_update_or_delete_another_session_cart_item(): void


### PR DESCRIPTION
## Summary
- Add safe cart/cart-item resources for public cart responses.
- Stop raw `items.variant.product` models from leaking internal product/variant economics.
- Skip inactive or hidden/R&D variants during cart merge and hide any stale hidden cart items from public cart payloads.

## Tests
- `php artisan test`
- `php artisan route:list`
- `npm run lint`
- `npm run build`
- `npm test`
- `npm run test:responsive`

## Browser/API QA
- Added product to cart from browser and inspected `POST /api/cart/items`: no forbidden fields.
- Inspected `localStorage.nafas_cart`: no forbidden fields.
- Confirmed cart page renders, quantity update returns sanitized JSON, and COD checkout still completes.

Closes #11.